### PR TITLE
Display the version of pip included inside get-pip.py

### DIFF
--- a/2.6/get-pip.py
+++ b/2.6/get-pip.py
@@ -4,7 +4,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip.
+# an entire copy of pip (version 9.0.1).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py

--- a/3.2/get-pip.py
+++ b/3.2/get-pip.py
@@ -4,7 +4,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip.
+# an entire copy of pip (version 7.1.2).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py

--- a/get-pip.py
+++ b/get-pip.py
@@ -4,7 +4,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip.
+# an entire copy of pip (version 9.0.1).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py

--- a/tasks/generate.py
+++ b/tasks/generate.py
@@ -80,6 +80,7 @@ def installer(ctx,
         fp.write(
             WRAPPER_TEMPLATE.format(
                 version="" if version is None else version,
+                latest=latest,
                 zipfile="\n".join(chunked),
             ),
         )

--- a/template.py
+++ b/template.py
@@ -4,7 +4,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip.
+# an entire copy of pip (version {latest}).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py


### PR DESCRIPTION
It seems a bit odd that the `get-pip.py` script contains a base85-encoded copy of the pip zipfile, and yet there's no way to see _which_ version of pip is included.

This PR fixes that ;-)