### PR TITLE
The PyPA has adopted the PSF code of conduct

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,6 @@ Code of Conduct
 ---------------
 
 Everyone interacting in the get-pip project's codebases, issue trackers, chat
-rooms, and mailing lists is expected to follow the `PyPA Code of Conduct`_.
+rooms, and mailing lists is expected to follow the `PSF Code of Conduct`_.
 
-.. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/
+.. PSF Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/


### PR DESCRIPTION
For details, see:

* https://discuss.python.org/t/implementing-pep-609-pypa-governance/4745