### PR TITLE
python2 error message

### DIFF
--- a/get-pip.py
+++ b/get-pip.py
@@ -34,8 +34,9 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     iterbytes = iter
 else:
-    def iterbytes(buf):
-        return (ord(byte) for byte in buf)
+    print("Python 2 is not supported with this version of get-pip.py. "
+          "Please use https://bootstrap.pypa.io/2.7/get-pip.py")
+    sys.exit(1)
 
 try:
     from base64 import b85decode

--- a/templates/default.py
+++ b/templates/default.py
@@ -34,8 +34,9 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     iterbytes = iter
 else:
-    def iterbytes(buf):
-        return (ord(byte) for byte in buf)
+    print("Python 2 is not supported with this version of get-pip.py. "
+          "Please use https://bootstrap.pypa.io/2.7/get-pip.py")
+    sys.exit(1)
 
 try:
     from base64 import b85decode


### PR DESCRIPTION
This shows a more informative error message when trying to use `get-pip.py` with Python 2. Something similar for Python 3.5 and older may also make sense.

Before:
```
$ python2 get-pip.py
Traceback (most recent call last):
  File "get-pip.py", line 24226, in <module>
    main()
  File "get-pip.py", line 199, in main
    bootstrap(tmpdir=tmpdir)
  File "get-pip.py", line 82, in bootstrap
    from pip._internal.cli.main import main as pip_entry_point
  File "/var/folders/h4/tkxs1nyx46zd3zclshdprkv00000gn/T/tmpIcTK5C/pip.zip/pip/_internal/cli/main.py", line 60
    sys.stderr.write(f"ERROR: {exc}")
                                   ^
SyntaxError: invalid syntax
```

After:
```
$ python2 get-pip.py
Python 2 is not supported with this version of get-pip.py. Please use https://bootstrap.pypa.io/2.7/get-pip.py
```

See also
https://github.com/pypa/pip/issues/9500#issuecomment-767184428
https://github.com/pypa/pip/issues/9501
https://github.com/pypa/pip/issues/9503
https://github.com/pypa/pip/issues/9513
https://github.com/pypa/pip/issues/9518
https://github.com/pypa/pip/issues/9520
https://github.com/pypa/pip/issues/9574
https://github.com/pypa/pip/issues/9577
https://github.com/pypa/pip/issues/9581
https://github.com/pypa/get-pip/issues/82
https://github.com/pypa/get-pip/issues/89
https://github.com/pypa/get-pip/issues/92
https://github.com/pypa/get-pip/issues/94
https://discuss.python.org/t/install-pip-on-ubuntu20-04-for-python2/6880
https://stackoverflow.com/questions/65866417/pip-install-failing-on-python2
https://stackoverflow.com/questions/65896334/python-pip-broken-wiith-sys-stderr-writeferror-exc
https://stackoverflow.com/questions/65932497/get-pip-py-returns-syntaxerror-invalid-syntax