### PR TITLE
Fix link to bootstrap get-pip.py for older Python

### DIFF
--- a/get-pip.py
+++ b/get-pip.py
@@ -28,7 +28,7 @@ if this_python < min_version:
     message_parts = [
         "This script does not work on Python {}.{}".format(*this_python),
         "The minimum supported Python version is {}.{}.".format(*min_version),
-        "Please use https://bootstrap.pypa.io/{}.{}/get-pip.py instead.".format(*this_python),
+        "Please use https://bootstrap.pypa.io/pip/{}.{}/get-pip.py instead.".format(*this_python),
     ]
     print("ERROR: " + " ".join(message_parts))
     sys.exit(1)


### PR DESCRIPTION
The error message when running `get-pip.py` for older unsupported versions of Python includes a link to, e.g. https://bootstrap.pypa.io/3.5/get-pip.py . Running the script at this address gives an error message including:

```
Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/3.5/get-pip.py
``` 

The original error message should just include the link directly to the correct script. 

Fixes #105 