### PR TITLE
Only run checks on `main` branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,8 @@ name: Check Scripts
 
 on:
   push:
+    branches:
+    - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
This is an unnecessary run, when making release PRs.