### PR TITLE
Remove Python 2.7 from CI as virtualenv desupported it

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -30,9 +30,6 @@ jobs:
     # Install supported Python versions
     - uses: actions/setup-python@v4
       with:
-        python-version: 2.7
-    - uses: actions/setup-python@v4
-      with:
         python-version: 3.7
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
The latest version of virtualenv [desupported Python 2.7](https://virtualenv.pypa.io/en/latest/changelog.html#features-20-22-0). Removing it from CI.