### PR TITLE
Add a digest for each get-pip.py file

### DIFF
--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -229,11 +229,11 @@ def determine_destination(base: str, variant: str) -> Path:
         public.mkdir()
 
     if variant == "default":
-        return public / "get-pip.py"
+        return public
 
-    retval = public / variant / "get-pip.py"
-    if not retval.parent.exists():
-        retval.parent.mkdir()
+    retval = public / variant
+    if not retval.exists():
+        retval.mkdir()
 
     return retval
 
@@ -270,10 +270,13 @@ def generate_one(variant, mapping, *, console, pip_versions):
             wheel_version=mapping["wheel"],
             minimum_supported_version=mapping["minimum_supported_version"],
         )
-    # Write the script to the correct location
+
     destination = determine_destination("public", variant)
-    console.log(f"  Writing [blue]{destination}")
-    with destination.open("w", newline=newline) as f:
+
+    # Write the script to the correct location
+    get_pip = destination / "get-pip.py"
+    console.log(f"  Writing [blue]{get_pip}")
+    with get_pip.open("w", newline=newline) as f:
         f.write(rendered_template)
 
 

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -279,6 +279,12 @@ def generate_one(variant, mapping, *, console, pip_versions):
     with get_pip.open("w", newline=newline) as f:
         f.write(rendered_template)
 
+    # Write a digest of the script to the correct location
+    digest = destination / "get-pip.py.sha256"
+    console.log(f"  Writing [blue]{digest}")
+    with digest.open("w", newline=newline) as f:
+        f.write(hashlib.sha256(rendered_template.encode("utf-8")).hexdigest())
+
 
 def generate_moved(destination: str, *, location: str, console: Console):
     template = Path("templates") / "moved.py"

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -248,7 +248,7 @@ def detect_newline(f: TextIO) -> str:
 
 
 def generate_one(variant, mapping, *, console, pip_versions):
-    # Determing the correct wheel to download
+    # Determining the correct wheel to download
     pip_version = determine_latest(pip_versions.keys(), constraint=mapping["pip"])
     wheel_url, wheel_hash = pip_versions[pip_version]
 


### PR DESCRIPTION
Relates to: https://github.com/pypa/get-pip/issues/47

This PR adds a SHA256 digest of the get-pip.py file (alongside the get-pip.py file). This seems like a useful first step towards providing mechanisms for users to validate the integrity and authenticity of the get-pip.py file.

With these changes, the output of the script now looks like this (there are now two files being output for each version in the public directories):

<img width="1728" alt="Screenshot 2024-03-18 at 7 39 39 PM" src="https://github.com/pypa/get-pip/assets/1699723/8eb581d7-807e-4828-9631-c2dbbbee3f60">


The SHAs can be verified in bulk as follows (the output consists of the directory, a digest for the get-pip.py file, the related digest in the *.sha246 file, and a boolean representing whether the two digests match):
```
>>> import hashlib
>>> import os
>>>
>>> for _path, _, _ in os.walk("./public"):
...     print(_path, end=": ")
...     hash = hashlib.sha256()
...     with open(os.path.join(_path, "get-pip.py"), "rb") as f:
...         for b_block in iter(lambda: f.read(4096), b""):
...             hash.update(b_block)
...     digest = hash.hexdigest()
...     print(digest, end=":")
...     with open (os.path.join(_path, "get-pip.py.sha256"), "r") as f:
...         file_digest = f.readlines()[0].strip()
...         print(file_digest, end=":")
...         print(digest == file_digest)
...
./public: dfe9fd5c28dc98b5ac17979a953ea550cec37ae1b47a5116007395bfacff2ab9:dfe9fd5c28dc98b5ac17979a953ea550cec37ae1b47a5116007395bfacff2ab9:True
./public/3.3: 9698fcacf9011da4f0a3cabebe679dbb1509d19b3493e8c8c9c26dd74faf5cd0:9698fcacf9011da4f0a3cabebe679dbb1509d19b3493e8c8c9c26dd74faf5cd0:True
./public/3.4: dbd5dae3d1e7f6df844d630cdf65e0f0d98e483c9997daea17c7c9d86f7b38ad:dbd5dae3d1e7f6df844d630cdf65e0f0d98e483c9997daea17c7c9d86f7b38ad:True
./public/3.5: 311afebb7cdd310eb3a3a6bb6fffef53d84493db98c7cebf4008a18d3418c8be:311afebb7cdd310eb3a3a6bb6fffef53d84493db98c7cebf4008a18d3418c8be:True
./public/3.2: bcd45dea17cff6e8b2beb383ee3cb7c25b4d30b3bac9d01fc0220d1fd3d87de9:bcd45dea17cff6e8b2beb383ee3cb7c25b4d30b3bac9d01fc0220d1fd3d87de9:True
./public/2.7: 40ee07eac6674b8d60fce2bbabc148cf0e2f1408c167683f110fd608b8d6f416:40ee07eac6674b8d60fce2bbabc148cf0e2f1408c167683f110fd608b8d6f416:True
./public/2.6: 6e1a2feaa6a90b844e36c4f8ccdc222dcebcf581a1b2f9dab09fa72e53ead0e5:6e1a2feaa6a90b844e36c4f8ccdc222dcebcf581a1b2f9dab09fa72e53ead0e5:True
./public/3.6: 0bd6aa5c457b84958cebfe1bd34aec9fa98212a65fe962dbed1195425aea58e1:0bd6aa5c457b84958cebfe1bd34aec9fa98212a65fe962dbed1195425aea58e1:True
```

The SHAs can also be verified directly/simply using something like `sha256sum`:

<img width="1227" alt="Screenshot 2024-03-18 at 10 12 00 PM" src="https://github.com/pypa/get-pip/assets/1699723/47317485-79b8-4d2e-9154-f9db465683bb">

