### PR TITLE
Test against Python 3.11, 3.12 and 3.13 in CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,8 +11,8 @@ jobs:
     name: "are correctly generated"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - run: pip install nox
 
     - run: nox -s generate
@@ -23,23 +23,34 @@ jobs:
     name: "work as advertised"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - run: pip install nox
 
-    # Install supported Python versions
-    - uses: actions/setup-python@v4
+    # Install supported Python versions. Keep in sync with noxfile.py as
+    # much as possible, however, GitHub Actions eventually drops support
+    # for EOL Python versions, at which point we can't test them in CI.
+    - uses: actions/setup-python@v5
       with:
-        python-version: 3.7
-    - uses: actions/setup-python@v4
+        python-version: "3.7"
+    - uses: actions/setup-python@v5
       with:
-        python-version: 3.8
-    - uses: actions/setup-python@v4
+        python-version: "3.8"
+    - uses: actions/setup-python@v5
       with:
-        python-version: 3.9
-    - uses: actions/setup-python@v4
+        python-version: "3.9"
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.10"
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.13-dev"
 
     # Check that the scripts work.
     - run: nox -s check --no-error-on-missing-interpreters

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,22 @@ nox.options.sessions = ["check", "generate"]
 
 # Keep versions in sync with .github/workflows/check.yml
 @nox.session(
-    python=["2.6", "2.7", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
+    python=[
+        "2.6",
+        "2.7",
+        "3.2",
+        "3.3",
+        "3.4",
+        "3.5",
+        "3.6",
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+        "3.13",
+    ]
 )
 def check(session):
     """Ensure that get-pip.py for various Python versions, works on that version."""


### PR DESCRIPTION
Previously local and CI tests would only run against Python 3.10 and older.

Now, Python 3.11, 3.12 and the prerelease versions of 3.13 are tested too in CI, and will also be locally if installed.

This improves test coverage, and also gives more flexibility when running nox locally, since there is a greater chance it will find a matching Python version rather than skipping all tests if eg only newer Python is installed.

I've also upgraded the setup-python and checkout actions to their latest versions:
https://github.com/actions/setup-python/releases
https://github.com/actions/checkout/releases

Closes #203 