### PR TITLE
Add `.venv/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.nox/
+/.venv/
 /venv/
 __pycache__/
 .web_cache/


### PR DESCRIPTION
Since it's becoming increasingly more common than `venv/`.