### PR TITLE
Drop run-time version constraints for modern pip

### DIFF
--- a/public/2.6/get-pip.py
+++ b/public/2.6/get-pip.py
@@ -147,11 +147,11 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip<10"]
+        args += ["pip"]
     if implicit_setuptools:
-        args += ["setuptools<37"]
+        args += ["setuptools"]
     if implicit_wheel:
-        args += ["wheel<0.30"]
+        args += ["wheel"]
 
     delete_tmpdir = False
     try:

--- a/public/2.7/get-pip.py
+++ b/public/2.7/get-pip.py
@@ -149,9 +149,9 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip<21.0"]
+        args += ["pip"]
     if implicit_setuptools:
-        args += ["setuptools<45"]
+        args += ["setuptools"]
     if implicit_wheel:
         args += ["wheel"]
 

--- a/public/3.3/get-pip.py
+++ b/public/3.3/get-pip.py
@@ -147,11 +147,11 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip<18"]
+        args += ["pip"]
     if implicit_setuptools:
         args += ["setuptools"]
     if implicit_wheel:
-        args += ["wheel<0.30"]
+        args += ["wheel"]
 
     # Add our default arguments
     args = ["install", "--upgrade", "--force-reinstall"] + args

--- a/public/3.4/get-pip.py
+++ b/public/3.4/get-pip.py
@@ -147,7 +147,7 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip<19.2"]
+        args += ["pip"]
     if implicit_setuptools:
         args += ["setuptools"]
     if implicit_wheel:

--- a/public/3.5/get-pip.py
+++ b/public/3.5/get-pip.py
@@ -149,7 +149,7 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip<21.0"]
+        args += ["pip"]
     if implicit_setuptools:
         args += ["setuptools"]
     if implicit_wheel:

--- a/public/3.6/get-pip.py
+++ b/public/3.6/get-pip.py
@@ -71,7 +71,7 @@ def determine_pip_install_arguments():
     pre_parser.add_argument("--no-wheel", action="store_true")
     pre, args = pre_parser.parse_known_args()
 
-    args.append("pip<22.0")
+    args.append("pip")
 
     if include_setuptools(pre):
         args.append("setuptools")

--- a/public/3.7/get-pip.py
+++ b/public/3.7/get-pip.py
@@ -71,7 +71,7 @@ def determine_pip_install_arguments():
     pre_parser.add_argument("--no-wheel", action="store_true")
     pre, args = pre_parser.parse_known_args()
 
-    args.append("pip<24.1")
+    args.append("pip")
 
     if include_setuptools(pre):
         args.append("setuptools")

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -23,48 +23,34 @@ from rich.console import Console
 SCRIPT_CONSTRAINTS = {
     "default": {
         "pip": "",
-        "setuptools": "",
-        "wheel": "",
     },
     "2.6": {
         "pip": "<10",
-        "setuptools": "<37",
-        "wheel": "<0.30",
     },
     "2.7": {
         "pip": "<21.0",
-        "setuptools": "<45",
-        "wheel": "",
     },
     "3.2": {
+        # Pip older than v9.0.0 does not support Requires-Python so we have to manually
+        # constrain the pip, setuptools and wheel versions that are installed at runtime.
         "pip": "<8",
         "setuptools": "<30",
         "wheel": "<0.30",
     },
     "3.3": {
         "pip": "<18",
-        "setuptools": "",
-        "wheel": "<0.30",
     },
     "3.4": {
         "pip": "<19.2",
-        "setuptools": "",
-        "wheel": "",
     },
     "3.5": {
         "pip": "<21.0",
-        "setuptools": "",
-        "wheel": "",
     },
     "3.6": {
         "pip": "<22.0",
-        "setuptools": "",
-        "wheel": "",
     },
     "3.7": {
         "pip": "<24.1",
-        "setuptools": "",
-        "wheel": "",
     },
 }
 
@@ -248,7 +234,7 @@ def detect_newline(f: TextIO) -> str:
 
 
 def generate_one(variant, mapping, *, console, pip_versions):
-    # Determing the correct wheel to download
+    # Determine the correct wheel to download
     pip_version = determine_latest(pip_versions.keys(), constraint=mapping["pip"])
     wheel_url, wheel_hash = pip_versions[pip_version]
 
@@ -264,10 +250,11 @@ def generate_one(variant, mapping, *, console, pip_versions):
         newline = detect_newline(f)
         rendered_template = f.read().format(
             zipfile=encoded_wheel,
-            installed_version=pip_version,
-            pip_version=mapping["pip"],
-            setuptools_version=mapping["setuptools"],
-            wheel_version=mapping["wheel"],
+            bundled_pip_version=pip_version,
+            # These constraints are only used for pip versions that don't support Requires-Python.
+            pip_version_constraint=mapping.get("pip"),
+            setuptools_version_constraint=mapping.get("setuptools"),
+            wheel_version_constraint=mapping.get("wheel"),
             minimum_supported_version=mapping["minimum_supported_version"],
         )
     # Write the script to the correct location

--- a/templates/default.py
+++ b/templates/default.py
@@ -5,7 +5,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip (version {installed_version}).
+# an entire copy of pip (version {bundled_pip_version}).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py
@@ -71,13 +71,13 @@ def determine_pip_install_arguments():
     pre_parser.add_argument("--no-wheel", action="store_true")
     pre, args = pre_parser.parse_known_args()
 
-    args.append("pip{pip_version}")
+    args.append("pip")
 
     if include_setuptools(pre):
-        args.append("setuptools{setuptools_version}")
+        args.append("setuptools")
 
     if include_wheel(pre):
-        args.append("wheel{wheel_version}")
+        args.append("wheel")
 
     return ["install", "--upgrade", "--force-reinstall"] + args
 

--- a/templates/pre-10.py
+++ b/templates/pre-10.py
@@ -5,7 +5,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip (version {installed_version}).
+# an entire copy of pip (version {bundled_pip_version}).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py
@@ -147,11 +147,11 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip{pip_version}"]
+        args += ["pip"]
     if implicit_setuptools:
-        args += ["setuptools{setuptools_version}"]
+        args += ["setuptools"]
     if implicit_wheel:
-        args += ["wheel{wheel_version}"]
+        args += ["wheel"]
 
     delete_tmpdir = False
     try:

--- a/templates/pre-18.1.py
+++ b/templates/pre-18.1.py
@@ -5,7 +5,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip (version {installed_version}).
+# an entire copy of pip (version {bundled_pip_version}).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py
@@ -147,11 +147,11 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip{pip_version}"]
+        args += ["pip"]
     if implicit_setuptools:
-        args += ["setuptools{setuptools_version}"]
+        args += ["setuptools"]
     if implicit_wheel:
-        args += ["wheel{wheel_version}"]
+        args += ["wheel"]
 
     # Add our default arguments
     args = ["install", "--upgrade", "--force-reinstall"] + args

--- a/templates/pre-21.0.py
+++ b/templates/pre-21.0.py
@@ -5,7 +5,7 @@
 # You may be wondering what this giant blob of binary data here is, you might
 # even be worried that we're up to something nefarious (good for you for being
 # paranoid!). This is a base85 encoding of a zip file, this zip file contains
-# an entire copy of pip (version {installed_version}).
+# an entire copy of pip (version {bundled_pip_version}).
 #
 # Pip is a thing that installs packages, pip itself is a package that someone
 # might want to install, especially if they're looking to run this get-pip.py
@@ -149,11 +149,11 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip{pip_version}"]
+        args += ["pip"]
     if implicit_setuptools:
-        args += ["setuptools{setuptools_version}"]
+        args += ["setuptools"]
     if implicit_wheel:
-        args += ["wheel{wheel_version}"]
+        args += ["wheel"]
 
     # Add our default arguments
     args = ["install", "--upgrade", "--force-reinstall"] + args

--- a/templates/pre-9.py
+++ b/templates/pre-9.py
@@ -79,9 +79,9 @@ except ImportError:
 
 def bootstrap(tmpdir=None):
     # Import pip so we can use it to install pip and maybe setuptools too
-    import pip._internal
-    from pip._internal.commands.install import InstallCommand
-    from pip._internal.req.constructors import install_req_from_line
+    import pip
+    from pip.commands.install import InstallCommand
+    from pip.req import InstallRequirement
 
     # Wrapper to provide default certificate with the lowest priority
     class CertInstallCommand(InstallCommand):
@@ -94,7 +94,7 @@ def bootstrap(tmpdir=None):
                 self.parser.defaults["cert"] = cert_path  # calculated below
             return super(CertInstallCommand, self).parse_args(args)
 
-    pip._internal.commands_dict["install"] = CertInstallCommand
+    pip.commands_dict["install"] = CertInstallCommand
 
     implicit_pip = True
     implicit_setuptools = True
@@ -134,7 +134,7 @@ def bootstrap(tmpdir=None):
     # install of them.
     for arg in args:
         try:
-            req = install_req_from_line(arg)
+            req = InstallRequirement.from_line(arg)
         except Exception:
             continue
 
@@ -147,14 +147,11 @@ def bootstrap(tmpdir=None):
 
     # Add any implicit installations to the end of our args
     if implicit_pip:
-        args += ["pip"]
+        args += ["pip{pip_version_constraint}"]
     if implicit_setuptools:
-        args += ["setuptools"]
+        args += ["setuptools{setuptools_version_constraint}"]
     if implicit_wheel:
-        args += ["wheel"]
-
-    # Add our default arguments
-    args = ["install", "--upgrade", "--force-reinstall"] + args
+        args += ["wheel{wheel_version_constraint}"]
 
     delete_tmpdir = False
     try:
@@ -168,11 +165,11 @@ def bootstrap(tmpdir=None):
         # can be passed to --cert
         cert_path = os.path.join(tmpdir, "cacert.pem")
         with open(cert_path, "wb") as cert:
-            cert.write(pkgutil.get_data("pip._vendor.certifi", "cacert.pem"))
+            cert.write(pkgutil.get_data("pip._vendor.requests", "cacert.pem"))
 
         # Execute the included pip and use it to install the latest pip and
         # setuptools from PyPI
-        sys.exit(pip._internal.main(args))
+        sys.exit(pip.main(["install", "--upgrade"] + args))
     finally:
         # Remove our temporary directory
         if delete_tmpdir and tmpdir:


### PR DESCRIPTION
Modern Pip (v9.0.0+) supports `Requires-Python` and so automatically takes the current Python version into account, when determining the latest version of packages that can be installed.

As such, for modern Pip we don't need to specify version range constraints for the pip/setuptools/wheel versions passed to the `pip install` at `get-pip.py` run-time.

This is the first step towards being able to remove `SCRIPT_CONSTRAINTS` and rely purely on `Requires-Python` metadata, per: https://github.com/pypa/get-pip/issues/88#issuecomment-798966926

I've intentionally left the "figure out what Pip version to embed in the template" part of template generation alone for now to keep the PR smaller, and have only changed the run-time `pip install` parts.

I had to add a new `pre-9.py` template file (created as a copy of `pre-10.py`), since it's only pip<9 that needs the various version constraint references in the template (and otherwise anything else that used `pre-10.py`, such as Python 2.6, would have had redundant version constraints). The new `pre-9.py` template is only used for Python 3.2.