### PR TITLE
Add missing punctuation to error message

### DIFF
--- a/public/3.6/get-pip.py
+++ b/public/3.6/get-pip.py
@@ -26,7 +26,7 @@ this_python = sys.version_info[:2]
 min_version = (3, 6)
 if this_python < min_version:
     message_parts = [
-        "This script does not work on Python {}.{}".format(*this_python),
+        "This script does not work on Python {}.{}.".format(*this_python),
         "The minimum supported Python version is {}.{}.".format(*min_version),
         "Please use https://bootstrap.pypa.io/pip/{}.{}/get-pip.py instead.".format(*this_python),
     ]

--- a/public/3.7/get-pip.py
+++ b/public/3.7/get-pip.py
@@ -26,7 +26,7 @@ this_python = sys.version_info[:2]
 min_version = (3, 7)
 if this_python < min_version:
     message_parts = [
-        "This script does not work on Python {}.{}".format(*this_python),
+        "This script does not work on Python {}.{}.".format(*this_python),
         "The minimum supported Python version is {}.{}.".format(*min_version),
         "Please use https://bootstrap.pypa.io/pip/{}.{}/get-pip.py instead.".format(*this_python),
     ]

--- a/public/get-pip.py
+++ b/public/get-pip.py
@@ -26,7 +26,7 @@ this_python = sys.version_info[:2]
 min_version = (3, 8)
 if this_python < min_version:
     message_parts = [
-        "This script does not work on Python {}.{}".format(*this_python),
+        "This script does not work on Python {}.{}.".format(*this_python),
         "The minimum supported Python version is {}.{}.".format(*min_version),
         "Please use https://bootstrap.pypa.io/pip/{}.{}/get-pip.py instead.".format(*this_python),
     ]

--- a/templates/default.py
+++ b/templates/default.py
@@ -26,7 +26,7 @@ this_python = sys.version_info[:2]
 min_version = {minimum_supported_version}
 if this_python < min_version:
     message_parts = [
-        "This script does not work on Python {{}}.{{}}".format(*this_python),
+        "This script does not work on Python {{}}.{{}}.".format(*this_python),
         "The minimum supported Python version is {{}}.{{}}.".format(*min_version),
         "Please use https://bootstrap.pypa.io/pip/{{}}.{{}}/get-pip.py instead.".format(*this_python),
     ]


### PR DESCRIPTION
Before:

```
ERROR: This script does not work on Python 3.7 The minimum supported Python
version is 3.8. Please use https://bootstrap.pypa.io/pip/3.7/get-pip.py instead.
```

After:

```
ERROR: This script does not work on Python 3.7. The minimum supported Python
version is 3.8. Please use https://bootstrap.pypa.io/pip/3.7/get-pip.py instead.
```
