### PR TITLE
ci: restrict check workflow permissions to read-only

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
     - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   correctly-generated:
     name: "are correctly generated"


### PR DESCRIPTION
This narrows the `GITHUB_TOKEN` for `.github/workflows/check.yml` to read-only.

- These jobs only check out the repo and run build/test steps, so `contents: read` covers them.
- Without an explicit block the token inherits the repo default, often write-enabled.
- Following the principle of least privilege from the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).

Behavior is unchanged.